### PR TITLE
Gomode tracker concept

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,29 +1,39 @@
 <!doctype html>
 <html lang="en">
 <head>
-  <meta charset="utf-8"/>
+  <meta charset="utf-8" />
   <title>launching ALttP tracker</title>
   <script src="js/index.js"></script>
   <style>
   body { font-family: Arial, Helvetica, sans-serif; font-size: 14px; }
-  label { width: 5em; display: inline-block; }
-  div { margin: 5px 0; }
+  label { width: 15em; display: inline-block; }
+  label.radio { width: 10em; }
+  div, form { margin: 5px 0; }
   </style>
 </head>
 <body>
-
-  <div>
-    <label>Standard</label>
-    <button type="button" class="launch" data-mode="standard" data-map="no">Without map</button>
-    <button type="button" class="launch" data-mode="standard" data-map="yes">With map</button>
-  </div>
-
-  <div>
-    <label>Open</label>
-    <button type="button" class="launch" data-mode="open" data-map="no">Without map</button>
-    <button type="button" class="launch" data-mode="open" data-map="yes">With map</button>
-  </div>
-
+  <form id="configuration">
+    <h2>Configuration</h2>
+    <div>
+      <label>Game mode</label>
+      <input id="standard" type="radio" name="mode" value="standard" checked /><label class="radio" for="standard">Standard</label>
+      <input id="open" type="radio" name="mode" value="open" /><label class="radio" for="open">Open</label>
+    </div>
+    <div>
+      <label>Show map</label>
+      <input id="nomap" type="radio" name="map" value="no" checked /><label class="radio" for="nomap">No</label>
+      <input id="map" type="radio" name="map" value="yes" /><label class="radio" for="map">Yes</label>
+    </div>
+    <div>
+      <label>Show gomode indicators</label>
+      <input id="nogomode" type="radio" name="gomode" value="no" checked /><label class="radio" for="nogomode">Hide</label>
+      <input id="gomode-n" type="radio" name="gomode" value="ng" /><label class="radio" for="gomode-n">No glitches</label>
+      <input id="gomode-m" type="radio" name="gomode" value="mg" /><label class="radio" for="gomode-m">Minor glitches</label>
+    </div>
+    <div>
+      <button type="button" class="launch">Start</button>
+    </div>
+  </form>
   <script>start()</script>
 
 </body>

--- a/js/index.js
+++ b/js/index.js
@@ -10,17 +10,31 @@
         };
     }
 
-    function launch_tracker() {
-        var mode = this.getAttribute('data-mode'),
-            map = this.getAttribute('data-map') === 'yes',
-            width = map ? 1340 : 448;
+    function get_radio_configuration(name) {
+        var radios = document.getElementsByName(name)
+        for (var i = 0; i < radios.length; i++) {
+            if (radios[i].checked) {
+                return radios[i].value;
+            }
+        }
 
-        open('tracker.html?mode={mode}{map}'
+    }
+
+    function launch_tracker() {
+        var mode = get_radio_configuration('mode'),
+            map = get_radio_configuration('map') === 'yes',
+            gomode = get_radio_configuration('gomode'),
+            width = map ? 1340 : 448,
+            height = gomode ? 548 : 448;
+
+        open('tracker.html?mode={mode}{map}&gomode={gomode}'
                 .replace('{mode}', mode)
-                .replace('{map}', map ? '&map' : ''),
+                .replace('{map}', map ? '&map' : '')
+                .replace('{gomode}', gomode),
             '',
-            'width={width},height=448,titlebar=0,menubar=0,toolbar=0,scrollbars=0,resizable=0'
-                .replace('{width}', width));
+            'width={width},height={height},titlebar=0,menubar=0,toolbar=0,scrollbars=0,resizable=0'
+                .replace('{width}', width)
+                .replace('{height}', height));
         setTimeout('window.close()', 5000);
     }
 

--- a/js/index.js
+++ b/js/index.js
@@ -25,7 +25,9 @@
             map = get_radio_configuration('map') === 'yes',
             gomode = get_radio_configuration('gomode'),
             width = map ? 1340 : 448,
-            height = gomode ? 548 : 448;
+            height = (gomode !== "no") ? 548 : 448;
+        console.log(gomode)
+        console.log(height)
 
         open('tracker.html?mode={mode}{map}&gomode={gomode}'
                 .replace('{mode}', mode)

--- a/js/main.js
+++ b/js/main.js
@@ -6,6 +6,16 @@
     window.medallions = [0, 0];
     window.mode = query.mode;
     window.map_enabled = query.map;
+    window.gomode_indicator = (query.gomode !== "no");
+    window.gomode_mode = query.gomode;
+
+    // Utility function: remove item from array.
+    window.arr_remove = function(array, element) {
+        const index = array.indexOf(element);
+        if (index !== -1) {
+            array.splice(index, 1);
+        }
+    }
 
     // Event of clicking on the item tracker
     window.toggle = function(label) {
@@ -53,6 +63,9 @@
                 toggle_agahnim();
             }
         }
+        if (gomode_indicator) {
+            update_gomode_list()
+        }
     };
 
     // event of clicking on a boss's pendant/crystal subsquare
@@ -69,6 +82,9 @@
                 if (!chests[pendant_chests[k]].is_opened)
                     document.getElementById('chestMap'+pendant_chests[k]).className = 'chest ' + chests[pendant_chests[k]].is_available();
             }
+        }
+        if (gomode_indicator) {
+            update_gomode_list()
         }
     };
 
@@ -93,7 +109,400 @@
             // Change the mouseover text on the map
             dungeons[8+n].caption = dungeons[8+n].caption.replace(/\{medallion\d+\}/, '{medallion'+medallions[n]+'}');
         }
+        if (gomode_indicator) {
+            update_gomode_list()
+        }
     };
+
+
+    if (gomode_indicator) {
+        // The list of gomode items required in all runs.
+        // Gomode lists in this document assumes that the player is capable of the most common skips: fake flippers, bomb jumps and navigating dark rooms
+        // if they choose minor glitches logic. If they choose no glitches logic, flippers and lamp is displayed where relevant.
+        // The minor glitches logic does require hovering, as it is a very difficult skip.
+        // The list shows hard required items in order to access all crystal bosses and all 22 items on the bottom floor of Ganon's Tower.
+        // The list does explicitly lists items which circumstantially block access to bosses;
+        // There are two instances of this in minor glitches: Boots for DP, fire source for ToH. In addition, no glitches requires hookshot or cane for IP.
+        // These measures are done to differentiate between Schrodinger's Go Mode and proper Go Mode. An experienced runner should be able to identify these items,
+        // while a less experienced runner may be confused by the list not containing an item required in their specific seed.
+        // Since these items however, are already required by the definition of the gomode list logic, they will be shown for different reasons.
+        // Items are defined as a list of [item name, item level]. For progressive items, the item level is a level that we must at least have in order to qualify
+        // (eg. 1 for fighter sword/power gloves). The level of bow follows the UI - 1 is silver arrows no bow, 2 is bow, 3 is bow with silver arrows.
+        // Items that are not progressive must have a negative number, I use -1 for this purpose. Negative numbers are not checked for levels, only for existence.
+        // Possible future TODO: Highlight Schrodinger's gomode - where game completion is a possibility but may be conditionally locked.
+        window.default_gomode_list = [
+            // Moon pearl is always required in no glitches/minor glitches logic.
+            ["moonpearl", -1],
+            // At least a master sword is required to damage Ganon.
+            ["sword", 2],
+            // Titan's Mitts is requires to open up the dark world portals capable of accessing Ganon's Tower.
+            ["glove", 2],
+            // Hookshot is required to cross the gap past Moldorm 2. We do not account for hovering.
+            ["hookshot", -1],
+            // The Cane of Somaria may be required to access the right side in Ganon's Tower.
+            ["somaria", -1],
+            // A fire source is always required to light the torches in upper GT and on the lower right side.
+                // In minor glitches, a bomb jump can be used with lamp for lower GT .
+                ["mg", ["or", ["lantern", -1], ["firerod", -1]]],
+                // In no glitches, we always require fire rod.
+                ["ng", ["firerod", -1]],
+            // Boots may be required for a big key on the GT torch.
+            ["boots", -1],
+            // A bow is always required to kill red mimics in GT.
+            ["bow", 2],
+            // Hammer is not explicitly required for GT, however, as more than 3 dungeons require it for progression, there is no run where a crystal
+            // is not in a hammerlocked dungeon.
+            ["hammer", -1]
+        ];
+
+        // Medallion class map. The number (of the medallion assigned to a dungeon) corresponds to a medallion class define in the style sheet.
+        window.t_medallions = {
+            0: "medallion-0",
+            1: "bombos",
+            2: "ether",
+            3: "quake"
+        };
+
+        // Lists of items required for each dungeon.
+        // This list assumes completability under some circumstances, for example, it doesn't require boots for desert.
+        window.boss_lists = {
+            // EP requires bow for completion and the ability to traverse one of the easiest dark rooms in the game. In no glitches, we still require lamp.
+            0: [["bow", 2], ["ng", ["lantern", -1]]],
+            // DP requires: mirror, mitts and flute; or book to enter. You also require a fire source to open the boss room.
+            1: [["or", ["mirror", -1], ["book", -1]], ["or", ["glove", 2], ["book", -1]], ["or", ["flute", -1], ["book", -1]], ["or", ["lantern", -1], ["firerod", -1]], ["boots", -1]],
+            // Hera requires mirror for access, or hookshot and hammer. It may also require a fire source, but not in all cases.
+            2: [["or", ["mirror", -1], ["hookshot", -1]], ["or", ["mirror", -1], ["hammer", -1]], ["or", ["lantern", -1], ["firerod", -1]]],
+            // PoD requires hammer and bow for completion. It may also require dark rooms which we assume the runner is capable of in minor glitches.
+            3: [["hammer", -1], ["bow", 2], ["ng", ["lantern", -1]]],
+            // Swamp always requires hammer, hookshot, flippers and mirror for completion.
+            4: [["hammer", -1], ["mirror", -1], ["flippers", -1], ["hookshot", -1]],
+            // SW requires a sword to cut the curtains and a fire rod to enter the boss part of the dungeon. We also require a fire source of any sort, but since we have
+            // fire rod, lantern is not included. For access, besides the already always required - for full game completion - hammer, we require power gloves or hookshot to access the dungeon.
+            // This will never be displayed as hookshot and mitts is always required by both logics of this indicator.
+            // Including all the cases separately here would honestly be a waste - at the end of the day, gomode includes all dungeons, not just one
+            // and therefore it wouldn't be logical to display aghanim in the list at any point.
+            5: [["sword", 1], ["firerod", -1], ["or", ["glove", 1], ["hookshot", -1]]],
+            // TT requires a hookshot or power gloves (with hammer or as mitts) to access much like SW.
+            6: [["or", ["glove", 1], ["hookshot", -1]]],
+            // IP requires flippers to access, but we assume the runner knows how to do fake flippers. Besides this, we need mitts to enter the dark world,
+            // hammer to access the boss room and an fire weapon to destroy ice.
+            7: [["hammer", -1], ["glove", 2], ["or", ["firerod", -1], ["bombos", -1]], ["ng", ["flippers", -1]], ["ng", ["or", ["somaria", -1], ["hookshot", -1]]]],
+            // MM requires mitts and flute to enter, a sword to use a medallion, the cane of somaria to open the door in the first dark room, and boots or hookshot to cross
+            // the first gap.
+            8: [["glove", 2], ["flute", -1], ["sword", 1], ["somaria", -1], ["or", ["boots", -1], ["hookshot", -1]], ["ng", ["lantern", -1]]],
+            // TR requires hammer and mitts to enter, a sword to use the medallion, the cane of somaria to traverse, and the fire and ice rods to beat the boss.
+            9: [["hammer", -1], ["glove", 2], ["somaria", -1], ["firerod", -1], ["icerod", -1], ["sword", 1], ["ng", ["lantern", -1]]]
+        };
+
+        // Lists to keep track of gomode items.
+        window.gomode_list_mt = [];
+        window.gomode_list_ors = [];
+
+        // Remove no glitches items from the lists if minor glitches, otherwise burn them into the lists.
+        window.filter_gomode_mode = function() {
+            var mg = (gomode_mode === "mg");
+            for (var j = 0; j < default_gomode_list.length; j++) {
+                if (default_gomode_list[j][0] === "ng") {
+                    if (mg) {
+                        arr_remove(default_gomode_list, default_gomode_list[j]);
+                        j--;
+                    } else {
+                        default_gomode_list[j] = default_gomode_list[j][1];
+                    }
+                } else if (default_gomode_list[j][0] === "mg") {
+                    if (!mg) {
+                        arr_remove(default_gomode_list, default_gomode_list[j]);
+                        j--;
+                    } else {
+                        default_gomode_list[j] = default_gomode_list[j][1];
+                    }
+                }
+            }
+            for (var i = 0; i <= 9; i++) {
+                for (var j = 0; j < boss_lists[i].length; j++) {
+                    if (boss_lists[i][j][0] === "ng") {
+                        if (mg) {
+                            arr_remove(boss_lists[i], boss_lists[i][j]);
+                            j--;
+                        } else {
+                            boss_lists[i][j] = boss_lists[i][j][1];
+                        }
+                    } else if (boss_lists[i][j][0] === "mg") {
+                        if (!mg) {
+                            arr_remove(boss_lists[i], boss_lists[i][j]);
+                            j--;
+                        } else {
+                            boss_lists[i][j] = boss_lists[i][j][1];
+                        }
+                    }
+                }
+            }
+        }
+
+        // Monster function to keep track of the items displayed in the list of items to acquire prior to entering go mode.
+        window.update_gomode_list = function() {
+            // Reset the list of gomode items.
+            gomode_list_mt = [];
+            gomode_list_ors = [];
+            // Add the items always required for gomode.
+            for (var i = 0; i < default_gomode_list.length; i++) {
+                var d = default_gomode_list[i]
+                if (d[0] == "or") {
+                    var has = false
+                    for (var k = 1; k < d.length; k++) {
+                        var e = d[k];
+                        if ((e[1] < 0 && items[e[0]]) || (e[1] > 0 && items[e[0]] >= e[1])) {
+                            has = true;
+                            break;
+                        }
+                    }
+                    if (!has) {
+                        gomode_list_ors.push(d);
+                    }
+                } else {
+                    if ((d[1] < 0 && !items[d[0]]) || (d[1] > 0 && items[d[0]] < d[1])) {
+                        gomode_list_mt.push(d);
+                    }
+                }
+            }
+            var mo = -1
+            // Check each dungeon, if the dungeon is a crystal dungeon, add its (bare minimum) required items to the list
+            for (var i = 0; i < 10; i++) {
+                if (prizes[i] >= 3) {
+                    // If this is a medallion dungeon, add the relevant medallion to the list. If we have an unknown medallion on a crystal dungeon, and we don't have
+                    // all 3 medallions, add the ? medallion to the list.
+                    if (i - 8 >= 0) {
+                        var mid = i-8;
+                        // We use mo to store MM's medallions, so it doesn't show up twice if TR is the same medallion.
+                        if (mo != medallions[mid]) {
+                            var t_med = t_medallions[medallions[mid]];
+                            // Check: if the medallion is known and we don't have it OR if the medallion is unknown and we don't have all three.
+                            if ((!items[t_med] && medallions[mid] !== 0) || (medallions[mid] === 0 && (!items[t_medallions[1]] || !items[t_medallions[2]] || !items[t_medallions[3]])) ) {
+                                gomode_list_mt.push([t_med, -1]);
+                            }
+                            mo = medallions[mid];
+                        }
+                    }
+                    // I called dungeon lists boss lists for some reason (possibly because the bosses are displayed on the tracker).
+                    var boss_list = boss_lists[i];
+                    for (var j = 0; j < boss_list.length; j++) {
+                        var boss_entry = boss_list[j];
+                        // Or entries signify that we need one of several items.
+                        // We sort these into a separate lists. The reason that we do this is to be able to check it against the complete list of required items.
+                        // We do not display any or clauses from which at least one of the items is already required.
+                        if (boss_entry[0] == "or") {
+                            var has = false;
+                            for (var k = 1; k < boss_entry.length; k++) {
+                                var d = boss_entry[k];
+                                if ((d[1] < 0 && items[d[0]]) || (d[1] > 0 && items[d[0]] >= d[1])) {
+                                    has = true;
+                                    break;
+                                }
+                            }
+                            if (!has) {
+                                gomode_list_ors.push(boss_entry);
+                            }
+                        } else {
+                            // Simple check: if an item is required and we don't have it, or if a progressive item is required and we don't have the appropriate level of it,
+                            // then we display it in the gomode list.
+                            if ((boss_entry[1] < 0 && !items[boss_entry[0]]) || (boss_entry[1] > 0 && items[boss_entry[0]] < boss_entry[1])) {
+                                var found = false;
+                                // Here we check the existing list to avoid duplicates. We also upgrade the level on a duplicate progressive entry if we require a higher level
+                                // than which we already require.
+                                for (var k = 0; k < gomode_list_mt.length; k++) {
+                                    if (gomode_list_mt[k][0] == boss_entry[0]) {
+                                        if (boss_entry[1] > gomode_list_mt[k][1]) {
+                                            gomode_list_mt[k][1] = boss_entry[1];
+                                        }
+                                        found = true;
+                                        break;
+                                    }
+                                }
+                                if (!found) {
+                                    gomode_list_mt.push(boss_entry);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            // This loop sorts out the OR entries that we don't need to display.
+            // We don't display OR entries when at least one of the items in the OR entry is already required.
+            for (var j = 0; gomode_list_ors.length > 0 && j < gomode_list_ors.length; j++) {
+                if (j < 0) {
+                    continue;
+                }
+                var or_entry = gomode_list_ors[j];
+                var check_failed = false;
+                // Filter out identical OR entries. We only care about or entries of the same size for sanity's sake.
+                for (var k = 0; k < j; k++) {
+                    var or_entry_2 = gomode_list_ors[k];
+                    if (or_entry.length != or_entry_2.length) {
+                        continue;
+                    }
+                    var has_count = 0;
+                    for (var l = 1; l < or_entry.length; l++) {
+                        for (var m = 1; m < or_entry_2.length; m++) {
+                            if (or_entry[l][0] === or_entry_2[m][0]) {
+                                if (or_entry[l][1] == or_entry_2[m][1]) {
+                                    has_count++;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    if (has_count == or_entry.length - 1) {
+                        arr_remove(gomode_list_ors, or_entry);
+                        j--;
+                        check_failed = true;
+                        break;
+                    }
+                }
+                if (check_failed) {
+                    continue;
+                }
+                for (var k = 1; k < or_entry.length; k++) {
+                    for (var l = 0; l < gomode_list_mt.length; l++) {
+                        var list_entry = gomode_list_mt[l];
+                        // Check: entry item in the list is same as in the or, and required with at least the same level for a progressive item or simply required for a non-progressive item.
+                        if (list_entry[0] === or_entry[k][0] && ((list_entry[1] > 0 && list_entry[1] >= or_entry[k][1]) || (list_entry[1] < 0))) {
+                            // Remove the or entry from the list of ors.
+                            arr_remove(gomode_list_ors, or_entry);
+                            j--;
+
+                        }
+                    }
+                }
+            }
+
+            // The remaining or entries should be ones where neither of the items in the or entry are explicitly required.
+            // Add these ors to the main list.
+            for (var j = 0; j < gomode_list_ors.length; j++) {
+                var or_entry = gomode_list_ors[j];
+                gomode_list_mt.push(or_entry);
+            }
+
+            // Assign HTML ids to the entries in the gomode item list. IDs is a list of IDs, ID assignment maps the IDs to the actual list entries which we will require for the display.
+            var ids = [];
+            var id_assignment = {};
+
+            // Create the HTML elements.
+            var gomode_container = document.getElementById('gomode').getElementsByTagName("div")[0];
+
+            // Calculated by hand. 7 items fits onto the mapless screen, 21 items fit on the screen with the map.
+            var gomode_width = map_enabled ? 21 : 7;
+
+            // We display up to the amount of items that neatly fit into the window. In mapless mode, this may mean that certain items won't be visible in the gomode list
+            // until early ones are fulfilled. I think this is fine as a simple display of "you need at least these items before you can be in gomode".
+            for (var i = 0; i < (gomode_list_mt.length < gomode_width ? gomode_list_mt.length : gomode_width); i++) {
+                // For simple item requirements, the element ID is "gomode-[item]"
+                var tid = gomode_list_mt[i][0];
+                // For ors, the element ID will be "gomode-[item1]-[item2]-[item3]..."
+                if (tid === "or") {
+                    tid = gomode_list_mt[i][1][0];
+                    for (var j = 2; j < gomode_list_mt[i].length; j++) {
+                        tid += "-"+gomode_list_mt[i][j][0];
+                    }
+                }
+                var eid = "gomode-"+tid;
+                ids.push(eid);
+                id_assignment[eid] = gomode_list_mt[i];
+            }
+            var c = gomode_container.getElementsByTagName("div");
+            for (var i = 0; i < c.length; i++) {
+                var node = c[i];
+                if (!(node.id in ids)) {
+                    node.remove();
+                    i--;
+                } else {
+                    arr_remove(ids, node.id);
+                }
+            }
+
+            // Here we construct the HTML elements.
+            for (var i = 0; i < ids.length; i++) {
+                var id = ids[i];
+                var el = document.createElement("div");
+                el.setAttribute("id", id);
+                gomode_container.appendChild(el);
+                var a = id_assignment[id];
+                // For ors, we divide a cell into 4 subcells. We currently don't use a 3-item or a 4-item or, probably never will, but the opportunity is there if needed.
+                // For the two-item ors, an item is neatly displayed in the top left and the bottom right.
+                if (a[0] === "or") {
+                    el.setAttribute("class", "cell item");
+
+                    var r1 = document.createElement("div");
+                    r1.setAttribute("class", "row");
+                    el.appendChild(r1);
+
+                    var r2 = document.createElement("div");
+                    r2.setAttribute("class", "row");
+                    el.appendChild(r2);
+
+                    var c1 = document.createElement("div");
+                    c1.setAttribute("class", "cell combination");
+                    r1.appendChild(c1);
+
+                    var c2 = document.createElement("div");
+                    c2.setAttribute("class", "cell combination");
+                    r1.appendChild(c2);
+
+                    var c3 = document.createElement("div");
+                    c3.setAttribute("class", "cell combination");
+                    r2.appendChild(c3);
+
+                    var c4 = document.createElement("div");
+                    c4.setAttribute("class", "cell combination");
+                    r2.appendChild(c4);
+
+                    var cn = a.length - 1;
+                    if (cn > 4) {
+                        cn = 4;
+                    }
+                    var cs = [];
+                    switch (cn) {
+                        case 1:
+                            cs = [c1];
+                            break;
+                        case 2:
+                            cs = [c1, c4];
+                            break;
+                        case 3:
+                            cs = [c1, c2, c3];
+                            break;
+                        case 4:
+                            cs = [c1, c2, c3, c4];
+                            break;
+                    }
+                    for (var l = 1; l < a.length; l++) {
+                        var act = a[l];
+                        if (act[1] < 0) {
+                            cs[l-1].setAttribute("class", "cell item combination " + act[0]);
+                        } else {
+                            cs[l-1].setAttribute("class", "cell item combination " + act[0] + " active-" + act[1]);
+                        }
+                    }
+                } else {
+                    if (a[1] < 0) {
+                        el.setAttribute("class", "cell item " + a[0]);
+                    } else {
+                        el.setAttribute("class", "cell item " + a[0] + " active-" + a[1]);
+                    }
+                }
+            }
+
+            // Add the go mode text.
+            var gomode_text = document.getElementById('gomode').getElementsByTagName("span")[0]
+            if (gomode_list_mt.length > 0) {
+                gomode_text.textContent = "Go mode not ready";
+                gomode_text.setAttribute("class", "caption");
+            } else {
+                gomode_text.textContent = "Go!";
+                gomode_text.setAttribute("class", "caption go");
+            }
+
+        }
+    }
 
     if (map_enabled) {
         // Event of clicking a chest on the map
@@ -174,6 +583,13 @@
         } else {
             document.getElementById('app').classList.add('mapless');
             document.getElementById('map').style.display = 'none';
+        }
+
+        if (gomode_indicator) {
+            filter_gomode_mode();
+            update_gomode_list();
+        } else {
+            document.getElementById('gomode').style.display = 'none';
         }
     };
 }(window));

--- a/style.css
+++ b/style.css
@@ -12,12 +12,18 @@ body {
 .row:after { clear: both; }
 .cell { position: relative; float: left; }
 
-#app { width: 1340px; height: 448px; }
+#app { width: 1340px; height: 548px; }
 #app.mapless { width: 448px; }
+
+span.caption { color: white; font-weight: bold; font-size: 20px; }
+span.caption.go { color: red; }
 
 #tracker .item,
 #tracker .boss,
 #tracker [id^="chest"] { width: 64px; height: 64px; }
+
+#gomode .item { width: 64px; height: 64px; background-size: 64px 64px; }
+#gomode .combination { width: 32px; height: 32px; background-size: 32px 32px; }
 
 #tracker .tunic { width: 128px; height: 128px; }
 #tracker .sword { position: absolute; top: 0; right: 0; }
@@ -32,6 +38,7 @@ body {
 
 #tracker .item,
 #tracker .boss { opacity: .25; }
+#gomode .item,
 #tracker .item[class*="active"],
 #tracker .boss.defeated { opacity: 1; }
 

--- a/tracker.html
+++ b/tracker.html
@@ -1,9 +1,10 @@
 <!doctype html>
 <html lang="en">
 <head>
-  <meta charset="utf-8"/>
   <title>ALttP Rando Tracker by crossproduct &amp; halfarebel (v5.0.0)</title>
+
   <link rel="stylesheet" type="text/css" href="style.css">
+
   <script src="js/util.js"></script>
   <script src="js/items.js"></script>
   <script src="js/chests.js"></script>
@@ -216,6 +217,12 @@
       <div id="bossMap9" onMouseover="highlight_dungeon(9)" onMouseout="unhighlight_dungeon(9)"></div>
       <div id="dungeon9" onMouseover="highlight_dungeon(9)" onMouseout="unhighlight_dungeon(9)"></div>
       <div id="caption">&nbsp;</div>
+    </div>
+
+    <div id="gomode" class="cell">
+      <span class="caption">Go mode not ready</span>
+      <div class="row">
+      </div>
     </div>
   </div>
 


### PR DESCRIPTION
- Added a gomode indicator / tracker feature to optionally enable.

The primary goal is to help out runners with a visual indicator of the items missing for gomode. The indicator works with two logics: no glitches and minor glitches sans hovering. The former logic displays items that are required to beat the game without bomb jumping, fake flippers, the usual business, thus EP would require lamp, and IP would require flippers and hookshot or somaria. The minor glitches logic is a filter for more advanced runners.

The gomode indicator works off of a base list of items required to beat GT. It takes all crystals into an account and dynamically adjusts the list based on which dungeons are crystals. It displays every items that may be *optionally required* for completion as well - such as boots and somaria for GT, or a fire source for ToH. It also displays the medallion for TR and MM if not owned, as well as an unknown medallion symbol if all three medallions are not owned and one of these crystal dungeons have an unknown medallion. The indicator's list of items is a bare minimum requirement for completion, thus it takes alternate access into consideration; for example, if DP is a crystal, it displays an equivalent of "Boots AND (Book OR (Flute AND Mitts AND Mirror))". To avoid overcomplicating the logic, the list itself is a chain of AND clauses with each clause being either an item or a chain of OR clauses. The OR clauses where at least one of the items are already required or owned are removed to keep the size small.

As owned items are marked, matching items from the gomode indicator are removed. Once the list is empty, the caption changes to Go!.

The gomode list displays as many items as it possibly can without breaking the layout. That means a maximum of 7 items appear with the mapless option. With the map option, there is a hard limit of 21 items but there is no situation in which the list has that many entries.

The usage of the gomode indicator is optional and defaults to false. When it is enabled, it is displayed as a 100px bottom bar in the window.

- Updated index.html from button-based configuration to radio-based configuration.

As this PR introduces three new options to the front page, I took the liberty to reformat it to a radio button based configuration as to avoid having to buttonize each combination of options.