### PR TITLE
Right click functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,23 +16,29 @@
 <body>
 
   <div>
+    <label>Standard v29</label>
+    <button type="button" class="launch" data-mode="standard" data-map="no" data-sword="randomized">Tracker only</button>
+    <button type="button" class="launch" data-mode="standard" data-map="hmap" data-sword="randomized">Horizontal map</button>
+    <button type="button" class="launch" data-mode="standard" data-map="vmap" data-sword="randomized">Vertical map</button>
+  </div>
+
+  <div>
     <label>Standard</label>
-    <button type="button" class="launch" data-mode="standard" data-map="no">Tracker only</button>
-    <button type="button" class="launch" data-mode="standard" data-map="hmap">Horizontal map</button>
-    <button type="button" class="launch" data-mode="standard" data-map="vmap">Vertical map</button>
+    <button type="button" class="launch" data-mode="standard" data-map="no" data-sword="standard">Tracker only</button>
+    <button type="button" class="launch" data-mode="standard" data-map="hmap" data-sword="standard">Horizontal map</button>
+    <button type="button" class="launch" data-mode="standard" data-map="vmap" data-sword="standard">Vertical map</button>
   </div>
 
   <div>
     <label>Open</label>
-    <button type="button" class="launch" data-mode="open" data-map="no">Tracker only</button>
-    <button type="button" class="launch" data-mode="open" data-map="hmap">Horizontal map</button>
-    <button type="button" class="launch" data-mode="open" data-map="vmap">Vertical map</button>
+    <button type="button" class="launch" data-mode="open" data-map="no" data-sword="standard">Tracker only</button>
+    <button type="button" class="launch" data-mode="open" data-map="hmap" data-sword="standard">Horizontal map</button>
+    <button type="button" class="launch" data-mode="open" data-map="vmap" data-sword="standard">Vertical map</button>
   </div>
 
   <div>
     <label>Sprite</label>
     <select id="sprite">
-      <option value="" selected>Default</option>
       <option value="four-swords-link">Four Swords Link</option>
       <option value="boo">Boo</option>
       <option value="boy">Boy</option>
@@ -73,7 +79,7 @@
       <option value="old-man">Old Man</option>
       <option value="pink-ribbon-link">Pink Ribbon Link</option>
       <option value="popoi">Popoi</option>
-      <option value="pug">Pug</option>
+      <option value="pug" selected>Pug</option>
       <option value="purple-chest">Purple Chest</option>
       <option value="roy-koopa">Roy Koopa</option>
       <option value="rumia">Rumia</option>
@@ -103,8 +109,8 @@
     <select id="scale">
       <option value="">Unscaled 100%</option>
       <option value="90">Scaled 90%</option>
-      <option value="80">Scaled 80%</option>
-      <option value="70">Scaled 70%</option>
+      <option value="80" selected>Scaled 80%</option>
+      <option value="70" >Scaled 70%</option>
       <option value="60">Scaled 60%</option>
     </select>
   </div>

--- a/js/index.js
+++ b/js/index.js
@@ -13,6 +13,7 @@
     function launch_tracker() {
         var params = {
                 mode: this.getAttribute('data-mode'),
+                sword: this.getAttribute('data-sword'),
                 hmap: this.getAttribute('data-map') === 'hmap',
                 vmap: this.getAttribute('data-map') === 'vmap',
                 sprite: document.getElementById('sprite').value,
@@ -46,6 +47,7 @@
     function query(params) {
         return compact([
             'mode='+params.mode,
+            'sword='+params.sword,
             params.hmap && 'hmap',
             params.vmap && 'vmap',
             params.sprite && 'sprite='+params.sprite,

--- a/js/items.js
+++ b/js/items.js
@@ -30,6 +30,15 @@
             bow: { max: 3 },
             boomerang: { max: 3 },
             glove: { max: 2 }
+        }),
+        dec: counters(-1, {
+            tunic: { min: 1, max: 3 },
+            sword: { max: 4 },
+            shield: { max: 3 },
+            bottle: { max: 4 },
+            bow: { max: 3 },
+            boomerang: { max: 3 },
+            glove: { max: 2 }
         })
     };
 

--- a/js/items.js
+++ b/js/items.js
@@ -1,6 +1,6 @@
 (function(window) {
     'use strict';
-
+    var query = uri_query();
     var items = {
         has_melee: function() { return this.sword || this.hammer; },
         has_bow: function() { return this.bow > 1; },
@@ -87,7 +87,7 @@
         agahnim: false
     });
 
-    var standard_items = update(open_items, { sword: { $set: 1 } });
+    var standard_items = update(open_items, { sword: { $set: query.sword == "standard" ? 1 : 0 } });
 
     window.item_model = function(mode) {
         return { items: { standard: standard_items, open: open_items }[mode] };

--- a/js/locations.js
+++ b/js/locations.js
@@ -4,18 +4,19 @@
     function always() { return 'available'; }
 
     var dungeons = {
-        eastern: {
-            caption: 'Eastern Palace {lantern}',
-            chest_limit: 3,
+        hera: {
+            caption: 'Tower of Hera',
+            chest_limit: 2,
             is_completable: function(items) {
-                return items.has_bow() ?
-                    items.lantern ? 'available' : 'dark' :
-                    'unavailable';
+                if (!items.has_melee()) return 'unavailable';
+                return this.is_progressable(items);
             },
             is_progressable: function(items) {
-                return this.chests <= 2 && !items.lantern ||
-                    this.chests === 1 && !items.has_bow() ?
-                    'possible' : 'available';
+                if (!items.flute && !items.glove) return 'unavailable';
+                if (!items.mirror && !(items.hookshot && items.hammer)) return 'unavailable';
+                return items.firerod || items.lantern ?
+                    items.flute || items.lantern ? 'available' : 'dark' :
+                    'possible';
             }
         },
         desert: {
@@ -33,56 +34,18 @@
                 return this.chests > 1 && items.boots ? 'available' : 'possible';
             }
         },
-        hera: {
-            caption: 'Tower of Hera',
-            chest_limit: 2,
+        eastern: {
+            caption: 'Eastern Palace {lantern}',
+            chest_limit: 3,
             is_completable: function(items) {
-                if (!items.has_melee()) return 'unavailable';
-                return this.is_progressable(items);
+                return items.has_bow() ?
+                    items.lantern ? 'available' : 'dark' :
+                    'unavailable';
             },
             is_progressable: function(items) {
-                if (!items.flute && !items.glove) return 'unavailable';
-                if (!items.mirror && !(items.hookshot && items.hammer)) return 'unavailable';
-                return items.firerod || items.lantern ?
-                    items.flute || items.lantern ? 'available' : 'dark' :
-                    'possible';
-            }
-        },
-        darkness: {
-            caption: 'Palace of Darkness {lantern}',
-            darkworld: true,
-            chest_limit: 5,
-            is_completable: function(items) {
-                if (!items.moonpearl || !items.has_bow() || !items.hammer) return 'unavailable';
-                if (!items.agahnim && !items.glove) return 'unavailable';
-                return items.lantern ? 'available' : 'dark';
-            },
-            is_progressable: function(items) {
-                if (!items.moonpearl) return 'unavailable';
-                if (!items.agahnim && !(items.hammer && items.glove) && !(items.glove === 2 && items.flippers)) return 'unavailable';
-                return !(items.has_bow() && items.lantern) ||
-                    this.chests === 1 && !items.hammer ?
+                return this.chests <= 2 && !items.lantern ||
+                    this.chests === 1 && !items.has_bow() ?
                     'possible' : 'available';
-            }
-        },
-        swamp: {
-            caption: 'Swamp Palace {mirror}',
-            darkworld: true,
-            chest_limit: 6,
-            is_completable: function(items) {
-                if (!items.moonpearl || !items.mirror || !items.flippers) return 'unavailable';
-                if (!items.hammer || !items.hookshot) return 'unavailable';
-                if (!items.glove && !items.agahnim) return 'unavailable';
-                return 'available';
-            },
-            is_progressable: function(items) {
-                if (!items.moonpearl || !items.mirror || !items.flippers) return 'unavailable';
-                if (!items.can_reach_outcast() && !(items.agahnim && items.hammer)) return 'unavailable';
-
-                if (this.chests <= 2) return !items.hammer || !items.hookshot ? 'unavailable' : 'available';
-                if (this.chests <= 4) return !items.hammer ? 'unavailable' : !items.hookshot ? 'possible' : 'available';
-                if (this.chests <= 5) return !items.hammer ? 'unavailable' : 'available';
-                return !items.hammer ? 'possible' : 'available';
             }
         },
         skull: {
@@ -111,21 +74,6 @@
                 return this.chests === 1 && !items.hammer ? 'possible' : 'available';
             }
         },
-        ice: {
-            caption: 'Ice Palace (yellow=must bomb jump)',
-            darkworld: true,
-            chest_limit: 3,
-            is_completable: function(items) {
-                if (!items.moonpearl || !items.flippers || items.glove !== 2 || !items.hammer) return 'unavailable';
-                if (!items.firerod && !(items.bombos && items.sword)) return 'unavailable';
-                return items.hookshot || items.somaria ? 'available' : 'possible';
-            },
-            is_progressable: function(items) {
-                if (!items.moonpearl || !items.flippers || items.glove !== 2) return 'unavailable';
-                if (!items.firerod && !(items.bombos && items.sword)) return 'unavailable';
-                return items.hammer ? 'available' : 'possible';
-            }
-        },
         mire: {
             caption: medallion_caption('Misery Mire {medallion}{lantern}', 'mire'),
             darkworld: true,
@@ -151,6 +99,58 @@
                     items.lantern || items.firerod :
                     items.lantern && items.somaria) ?
                     'available' : 'possible';
+            }
+        },
+        swamp: {
+            caption: 'Swamp Palace {mirror}',
+            darkworld: true,
+            chest_limit: 6,
+            is_completable: function(items) {
+                if (!items.moonpearl || !items.mirror || !items.flippers) return 'unavailable';
+                if (!items.hammer || !items.hookshot) return 'unavailable';
+                if (!items.glove && !items.agahnim) return 'unavailable';
+                return 'available';
+            },
+            is_progressable: function(items) {
+                if (!items.moonpearl || !items.mirror || !items.flippers) return 'unavailable';
+                if (!items.can_reach_outcast() && !(items.agahnim && items.hammer)) return 'unavailable';
+
+                if (this.chests <= 2) return !items.hammer || !items.hookshot ? 'unavailable' : 'available';
+                if (this.chests <= 4) return !items.hammer ? 'unavailable' : !items.hookshot ? 'possible' : 'available';
+                if (this.chests <= 5) return !items.hammer ? 'unavailable' : 'available';
+                return !items.hammer ? 'possible' : 'available';
+            }
+        },
+        ice: {
+            caption: 'Ice Palace (yellow=must bomb jump)',
+            darkworld: true,
+            chest_limit: 3,
+            is_completable: function(items) {
+                if (!items.moonpearl || !items.flippers || items.glove !== 2 || !items.hammer) return 'unavailable';
+                if (!items.firerod && !(items.bombos && items.sword)) return 'unavailable';
+                return items.hookshot || items.somaria ? 'available' : 'possible';
+            },
+            is_progressable: function(items) {
+                if (!items.moonpearl || !items.flippers || items.glove !== 2) return 'unavailable';
+                if (!items.firerod && !(items.bombos && items.sword)) return 'unavailable';
+                return items.hammer ? 'available' : 'possible';
+            }
+        },
+        darkness: {
+            caption: 'Palace of Darkness {lantern}',
+            darkworld: true,
+            chest_limit: 5,
+            is_completable: function(items) {
+                if (!items.moonpearl || !items.has_bow() || !items.hammer) return 'unavailable';
+                if (!items.agahnim && !items.glove) return 'unavailable';
+                return items.lantern ? 'available' : 'dark';
+            },
+            is_progressable: function(items) {
+                if (!items.moonpearl) return 'unavailable';
+                if (!items.agahnim && !(items.hammer && items.glove) && !(items.glove === 2 && items.flippers)) return 'unavailable';
+                return !(items.has_bow() && items.lantern) ||
+                    this.chests === 1 && !items.hammer ?
+                    'possible' : 'available';
             }
         },
         turtle: {
@@ -662,16 +662,16 @@
 
     function finalize_dungeons(dungeons, apply) {
         return update(map_values(dungeons, function(d) { return create(d); }), {
-            eastern:  { $apply: apply, $merge: { completed: false, prize: 0 } },
-            desert:   { $apply: apply, $merge: { completed: false, prize: 0 } },
-            hera:     { $apply: apply, $merge: { completed: false, prize: 0 } },
-            darkness: { $apply: apply, $merge: { completed: false, prize: 0 } },
-            swamp:    { $apply: apply, $merge: { completed: false, prize: 0 } },
-            skull:    { $apply: apply, $merge: { completed: false, prize: 0 } },
-            thieves:  { $apply: apply, $merge: { completed: false, prize: 0 } },
-            ice:      { $apply: apply, $merge: { completed: false, prize: 0 } },
-            mire:     { $apply: apply, $merge: { completed: false, prize: 0, medallion: 0 } },
-            turtle:   { $apply: apply, $merge: { completed: false, prize: 0, medallion: 0 } },
+            eastern:  { $apply: apply, $merge: { completed: false, prize: 3 } },
+            desert:   { $apply: apply, $merge: { completed: false, prize: 3 } },
+            hera:     { $apply: apply, $merge: { completed: false, prize: 3 } },
+            darkness: { $apply: apply, $merge: { completed: false, prize: 3 } },
+            swamp:    { $apply: apply, $merge: { completed: false, prize: 3 } },
+            skull:    { $apply: apply, $merge: { completed: false, prize: 3 } },
+            thieves:  { $apply: apply, $merge: { completed: false, prize: 3 } },
+            ice:      { $apply: apply, $merge: { completed: false, prize: 3 } },
+            mire:     { $apply: apply, $merge: { completed: false, prize: 3, medallion: 0 } },
+            turtle:   { $apply: apply, $merge: { completed: false, prize: 3, medallion: 0 } },
         });
     }
 

--- a/js/main.js
+++ b/js/main.js
@@ -71,8 +71,9 @@
     };
 
     var Tracker = createReactClass({
+
         render: function() {
-            return div('#tracker', { className: classNames({ cell: this.props.horizontal })},
+            return div('#tracker', { className: classNames({ cell: this.props.horizontal  })},
                 grid([
                     grid([[
                         this.tunic(),
@@ -80,14 +81,14 @@
                         this.item('shield'),
                         this.item('moonpearl'),
                     ]], [
-                        this.dungeon('eastern'),
-                        this.chest('eastern')
+                        this.dungeon('hera'),
+                        this.chest('hera')
                     ], [
                         this.dungeon('desert'),
                         this.chest('desert')
                     ], [
-                        this.dungeon('hera'),
-                        this.chest('hera')
+                        this.dungeon('eastern'),
+                        this.chest('eastern')
                     ]),
                     grid([
                         this.item('bow'),
@@ -104,7 +105,8 @@
                     ], [
                         this.item('lantern'),
                         this.item('hammer'),
-                        this.item('shovel'),
+                        this.item('flute'),
+
                         this.item('net'),
                         this.item('book')
                     ], [
@@ -117,24 +119,24 @@
                         this.item('boots'),
                         this.item('glove'),
                         this.item('flippers'),
-                        this.item('flute'),
+                        this.item('shovel'),
                         this.item('agahnim')
                     ])
                 ], [
-                    this.dungeon('darkness'),
-                    this.dungeon('swamp'),
                     this.dungeon('skull'),
                     this.dungeon('thieves'),
-                    this.dungeon('ice'),
                     this.medallion_dungeon('mire'),
+                    this.dungeon('swamp'),
+                    this.dungeon('ice'),
+                    this.dungeon('darkness'),
                     this.medallion_dungeon('turtle')
                 ], [
-                    this.chest('darkness'),
-                    this.chest('swamp'),
                     this.chest('skull'),
                     this.chest('thieves'),
-                    this.chest('ice'),
                     this.chest('mire'),
+                    this.chest('swamp'),
+                    this.chest('ice'),
+                    this.chest('darkness'),
                     this.chest('turtle')
                 ]));
         },
@@ -320,8 +322,8 @@
                     div('.world-dark', locations[1].map(property('tag')))
                 ];
 
-            return div('#map', { className: classNames({ cell: this.props.horizontal }), onContextMenu: function(e) { e.preventDefault() }, },
-                this.props.horizontal ? grid.call(null, worlds) : worlds,
+            return div('#map', { className: classNames({ cell: this.props.horizontal  }), onContextMenu: function(e) { e.preventDefault() }, },
+                this.props.horizontal ? grid.call(null, worlds) : worlds ,
                 t(Caption, { text: this.state.caption })
             );
         },
@@ -343,6 +345,7 @@
     var App = createReactClass({
         getInitialState: function() {
             var mode = this.props.query.mode;
+            var sword = this.props.query.sword;
             return Object.assign(item_model(mode), location_model(mode));
         },
 
@@ -368,9 +371,10 @@
                     medallion_click_back: this.medallion_click_back,
                     chest_click: this.chest_click,
                     chest_click_back: this.chest_click_back,
-                    horizontal: query.hmap
+                    horizontal: query.hmap,
+                    vertical: query.vmap
                 }, this.state)),
-                (query.hmap || query.vmap) && t(Map, Object.assign({ chest_click: this.map_chest_click, horizontal: query.hmap }, this.state)));
+                (query.hmap || query.vmap) && t(Map, Object.assign({ chest_click: this.map_chest_click, horizontal: query.hmap, vertical: query.vmap }, this.state)));
         },
 
         item_click: function(name) {

--- a/js/main.js
+++ b/js/main.js
@@ -209,6 +209,7 @@
                     highlight: props.highlighted
                 }),
             onClick: function() { props.onClick(name) },
+            onContextMenu: function(e) { e.preventDefault() },
             onMouseOver: function() { props.onHighlight(true); },
             onMouseOut: function() { props.onHighlight(false); }
         });
@@ -222,6 +223,7 @@
         return [
             div('.boss', {
                 className: as_location(name),
+                onContextMenu: function(e) { e.preventDefault() },
                 onMouseOver: function() { props.onHighlight(true); },
                 onMouseOut: function() { props.onHighlight(false); }
             }),
@@ -232,6 +234,7 @@
                         marked: completed,
                         highlight: props.highlighted
                     }),
+                onContextMenu: function(e) { e.preventDefault() },
                 onMouseOver: function() { props.onHighlight(true); },
                 onMouseOut: function() { props.onHighlight(false); }
             })
@@ -248,6 +251,7 @@
                     as_location(name),
                     dungeon.completed || dungeon.is_completable(model.items, model),
                     { marked: dungeon.completed }),
+                onContextMenu: function(e) { e.preventDefault() },
                 onMouseOver: function() { props.onHighlight(true); },
                 onMouseOut: function() { props.onHighlight(false); }
             }),
@@ -258,6 +262,7 @@
                         marked: dungeon.chests === 0,
                         highlight: props.highlighted
                     }),
+                onContextMenu: function(e) { e.preventDefault() },
                 onMouseOver: function() { props.onHighlight(true); },
                 onMouseOut: function() { props.onHighlight(false); }
             })

--- a/js/main.js
+++ b/js/main.js
@@ -10,7 +10,8 @@
             className: classNames(name,
                 value === true ? 'active' :
                 value > 0 ? 'active-'+value : null),
-            onClick: function() { props.onClick(name); }
+            onClick: function() { props.onClick(name) },
+            onContextMenu: function(e) { e.preventDefault(); props.ContextMenu(name)  }
         });
     };
 
@@ -137,7 +138,7 @@
         },
 
         item: function(name) {
-            return t(Item, { name: name, value: this.props.items[name], onClick: this.props.item_click });
+            return t(Item, { name: name, value: this.props.items[name], onClick: this.props.item_click, ContextMenu: this.props.item_click_back });
         },
 
         dungeon: function(name) {
@@ -345,6 +346,7 @@
                 },
                 t(Tracker, Object.assign({
                     item_click: this.item_click,
+                    item_click_back: this.item_click_back,
                     boss_click: this.boss_click,
                     prize_click: this.prize_click,
                     medallion_click: this.medallion_click,
@@ -359,6 +361,13 @@
                 change = typeof items[name] === 'boolean' ?
                     { $toggle: [name] } :
                     at(name, { $set: items.inc(name) });
+            this.setState(update(this.state, { items: change }));
+        },
+        item_click_back: function(name) {
+            var items = this.state.items,
+                change = typeof items[name] === 'boolean' ?
+                    { $toggle: [name] } :
+                    at(name, { $set: items.dec(name) });
             this.setState(update(this.state, { items: change }));
         },
 

--- a/js/main.js
+++ b/js/main.js
@@ -20,7 +20,9 @@
             has_pearl = props.items.moonpearl;
         return div('.item.tunic', {
             className: classNames('active-'+value, { bunny: !has_pearl }),
-            onClick: function() { props.onClick('tunic'); }
+            onClick: function() { props.onClick('tunic'); },
+            onContextMenu: function(e) { e.preventDefault(); props.ContextMenu('tunic')  }
+
         });
     };
 
@@ -30,11 +32,13 @@
         return [
             div('.boss', {
                 className: classNames(name, { defeated: dungeon.completed }),
-                onClick: function() { props.onBossClick(name); }
+                onClick: function() { props.onBossClick(name); },
+                onContextMenu: function(e) { e.preventDefault(); }
             }),
             div('.prize', {
                 className: 'prize-'+dungeon.prize,
-                onClick: function() { props.onPrizeClick(name); }
+                onClick: function() { props.onPrizeClick(name); },
+                onContextMenu: function(e) { e.preventDefault(); props.onPrizeClickBack(name) }
             })
         ];
     };
@@ -47,7 +51,8 @@
                 t(Wrapped, props),
                 div('.medallion', {
                     className: 'medallion-'+dungeon.medallion,
-                    onClick: function() { props.onMedallionClick(name); }
+                    onClick: function() { props.onMedallionClick(name); },
+                    onContextMenu: function(e) { e.preventDefault(); props.onMedallionClickBack(name) }
                 })
             ];
         };
@@ -60,7 +65,8 @@
             dungeon = props.value;
         return div('.chest', {
             className: 'chest-'+dungeon.chests,
-            onClick: function() { props.onClick(name); }
+            onClick: function() { props.onClick(name); },
+            onContextMenu: function(e) { e.preventDefault(); props.ContextMenu(name) }
         });
     };
 
@@ -134,7 +140,7 @@
         },
 
         tunic: function() {
-            return t(TunicItem, { items: this.props.items, onClick: this.props.item_click });
+            return t(TunicItem, { items: this.props.items, onClick: this.props.item_click, ContextMenu: this.props.item_click_back });
         },
 
         item: function(name) {
@@ -146,7 +152,8 @@
                 name: name,
                 value: this.props.dungeons[name],
                 onBossClick: this.props.boss_click,
-                onPrizeClick: this.props.prize_click });
+                onPrizeClick: this.props.prize_click,
+                onPrizeClickBack: this.props.prize_click_back });
         },
 
         medallion_dungeon: function(name) {
@@ -155,11 +162,13 @@
                 value: this.props.dungeons[name],
                 onBossClick: this.props.boss_click,
                 onPrizeClick: this.props.prize_click,
-                onMedallionClick: this.props.medallion_click });
+                onPrizeClickBack: this.props.prize_click_back,
+                onMedallionClick: this.props.medallion_click,
+                onMedallionClickBack: this.props.medallion_click_back });
         },
 
         chest: function(name) {
-            return t(Chest, { name: name, value: this.props.dungeons[name], onClick: this.props.chest_click });
+            return t(Chest, { name: name, value: this.props.dungeons[name], onClick: this.props.chest_click, ContextMenu: this.props.chest_click_back });
         }
     });
 
@@ -349,8 +358,11 @@
                     item_click_back: this.item_click_back,
                     boss_click: this.boss_click,
                     prize_click: this.prize_click,
+                    prize_click_back: this.prize_click_back,
                     medallion_click: this.medallion_click,
+                    medallion_click_back: this.medallion_click_back,
                     chest_click: this.chest_click,
+                    chest_click_back: this.chest_click_back,
                     horizontal: query.hmap
                 }, this.state)),
                 (query.hmap || query.vmap) && t(Map, Object.assign({ chest_click: this.map_chest_click, horizontal: query.hmap }, this.state)));
@@ -374,9 +386,12 @@
         boss_click: function(name) {
             this.setState(update(this.state, { dungeons: at(name, { $toggle: ['completed'] }) }));
         },
-
         prize_click: function(name) {
             var value = counter(this.state.dungeons[name].prize, 1, 4);
+            this.setState(update(this.state, { dungeons: at(name, { prize: { $set: value } }) }));
+        },
+        prize_click_back: function(name) {
+            var value = counter(this.state.dungeons[name].prize, -1, 4);
             this.setState(update(this.state, { dungeons: at(name, { prize: { $set: value } }) }));
         },
 
@@ -384,13 +399,20 @@
             var value = counter(this.state.dungeons[name].medallion, 1, 3);
             this.setState(update(this.state, { dungeons: at(name, { medallion: { $set: value } }) }));
         },
-
+        medallion_click_back: function(name) {
+            var value = counter(this.state.dungeons[name].medallion, -1, 3);
+            this.setState(update(this.state, { dungeons: at(name, { medallion: { $set: value } }) }));
+        },
         chest_click: function(name) {
             var dungeon = this.state.dungeons[name],
                 value = counter(dungeon.chests, -1, dungeon.chest_limit);
             this.setState(update(this.state, { dungeons: at(name, { chests: { $set: value } }) }));
         },
-
+        chest_click_back: function(name) {
+            var dungeon = this.state.dungeons[name],
+                value = counter(dungeon.chests, 1, dungeon.chest_limit);
+            this.setState(update(this.state, { dungeons: at(name, { chests: { $set: value } }) }));
+        },
         map_chest_click: function(name) {
             this.setState(update(this.state, { chests: at(name, { $toggle: ['marked'] }) }));
         }

--- a/js/main.js
+++ b/js/main.js
@@ -320,7 +320,7 @@
                     div('.world-dark', locations[1].map(property('tag')))
                 ];
 
-            return div('#map', { className: classNames({ cell: this.props.horizontal }) },
+            return div('#map', { className: classNames({ cell: this.props.horizontal }), onContextMenu: function(e) { e.preventDefault() }, },
                 this.props.horizontal ? grid.call(null, worlds) : worlds,
                 t(Caption, { text: this.state.caption })
             );


### PR DESCRIPTION
Added the ability to use right click on the tracker items.

Toggleable cells will do what they always did. 
Counted cells will reverse cell order (can clear all dungeon chests with a single right click vs X clicks)

Also my first time with React.JS so if there are better ways or if I did extra work, please let me know and I will look into fixing these things.